### PR TITLE
Update broken link to AMLD workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EmbracingUncertainty
 Material for Applied Machine Learning Days (AMLD) 2020 workshop "Bayesian Inference: embracing uncertainty": 
 
-https://appliedmldays.org/workshops/hands-on-bayesian-machine-learning-embracing-uncertainty
+https://appliedmldays.org/events/amld-epfl-2020/workshops/hands-on-bayesian-machine-learning-embracing-uncertainty
 
 ## Preparation
 


### PR DESCRIPTION
I've just updated the broken link to the AMLD 2020 workshop "Hands-on Bayesian Machine Learning: embracing uncertainty". 


Thank you very much for making this material publicly available. Very helpful! 